### PR TITLE
:sparkles: cleaning local snapshots

### DIFF
--- a/borg_backup/config.json
+++ b/borg_backup/config.json
@@ -1,15 +1,16 @@
 {
   "name": "BorgBackup",
-  "version": "0.56.3.3",
+  "version": "0.56.4",
   "slug": "borg_backup",
   "description": "BorgBackup as a Hassio Add-On - Fork by frigi83",
   "url": "https://github.com/frigi83/hassio-borg_backup",
   "startup": "once",
-  "boot": "auto",
+  "boot": "manual",
   "map": [
     "backup:rw"
   ],
-  "host_network": true,
+  "host_network": false,
+  "hassio_role": "backup",
   "options": {
     "user": null,
     "host": null,

--- a/borg_backup/config.json
+++ b/borg_backup/config.json
@@ -1,9 +1,9 @@
 {
   "name": "BorgBackup",
-  "version": "0.56",
+  "version": "0.56.1",
   "slug": "borg_backup",
-  "description": "BorgBackup as a Hassio Add-On",
-  "url": "https://github.com/yeah/hassio-borg_backup",
+  "description": "BorgBackup as a Hassio Add-On - Fork by frigi83",
+  "url": "https://github.com/frigi83/hassio-borg_backup",
   "startup": "once",
   "boot": "auto",
   "map": [

--- a/borg_backup/config.json
+++ b/borg_backup/config.json
@@ -1,6 +1,6 @@
 {
   "name": "BorgBackup",
-  "version": "0.56.3.1",
+  "version": "0.56.3.2",
   "slug": "borg_backup",
   "description": "BorgBackup as a Hassio Add-On - Fork by frigi83",
   "url": "https://github.com/frigi83/hassio-borg_backup",
@@ -18,9 +18,7 @@
     "archive": "hassio",
     "passphrase": null,
     "prune_options": "--keep-daily=8 --keep-weekly=5 --keep-monthly=13",
-    "local_snapshot": 3,
-    "private_key": null,
-    "public_key": null
+    "local_snapshot": 3
   },
   "schema": {
     "user": "str",
@@ -30,9 +28,7 @@
     "archive": "str",
     "passphrase": "password",
     "prune_options": "str?",
-    "local_snapshot": "int(0,)?",
-    "private_key": "str",
-    "public_key": "str"
+    "local_snapshot": "int(0,)?"
   },
   "arch": [
     "armhf",

--- a/borg_backup/config.json
+++ b/borg_backup/config.json
@@ -4,10 +4,10 @@
   "slug": "borg_backup",
   "description": "BorgBackup as a Hassio Add-On",
   "url": "https://github.com/yeah/hassio-borg_backup",
-  "startup": "before",
+  "startup": "once",
   "boot": "auto",
   "map": [
-    "backup"
+    "backup:rw"
   ],
   "host_network": true,
   "options": {
@@ -17,7 +17,8 @@
     "path": "~",
     "archive": "hassio",
     "passphrase": null,
-    "prune_options": "--keep-daily=8 --keep-weekly=5 --keep-monthly=13"
+    "prune_options": "--keep-daily=8 --keep-weekly=5 --keep-monthly=13",
+    "local_snapshot": 3
   },
   "schema": {
     "user": "str",
@@ -26,7 +27,8 @@
     "path": "str",
     "archive": "str",
     "passphrase": "password",
-    "prune_options": "str?"
+    "prune_options": "str?",
+    "local_snapshot": "int(0,)?"
   },
   "arch": [
     "armhf",

--- a/borg_backup/config.json
+++ b/borg_backup/config.json
@@ -1,6 +1,6 @@
 {
   "name": "BorgBackup",
-  "version": "0.56.3.0",
+  "version": "0.56.3.1",
   "slug": "borg_backup",
   "description": "BorgBackup as a Hassio Add-On - Fork by frigi83",
   "url": "https://github.com/frigi83/hassio-borg_backup",

--- a/borg_backup/config.json
+++ b/borg_backup/config.json
@@ -1,6 +1,6 @@
 {
   "name": "BorgBackup",
-  "version": "0.56.3.2",
+  "version": "0.56.3.3",
   "slug": "borg_backup",
   "description": "BorgBackup as a Hassio Add-On - Fork by frigi83",
   "url": "https://github.com/frigi83/hassio-borg_backup",

--- a/borg_backup/config.json
+++ b/borg_backup/config.json
@@ -1,6 +1,6 @@
 {
   "name": "BorgBackup",
-  "version": "0.56.2",
+  "version": "0.56.3.0",
   "slug": "borg_backup",
   "description": "BorgBackup as a Hassio Add-On - Fork by frigi83",
   "url": "https://github.com/frigi83/hassio-borg_backup",
@@ -18,7 +18,9 @@
     "archive": "hassio",
     "passphrase": null,
     "prune_options": "--keep-daily=8 --keep-weekly=5 --keep-monthly=13",
-    "local_snapshot": 3
+    "local_snapshot": 3,
+    "private_key": null,
+    "public_key": null
   },
   "schema": {
     "user": "str",
@@ -28,7 +30,9 @@
     "archive": "str",
     "passphrase": "password",
     "prune_options": "str?",
-    "local_snapshot": "int(0,)?"
+    "local_snapshot": "int(0,)?",
+    "private_key": "str",
+    "public_key": "str"
   },
   "arch": [
     "armhf",

--- a/borg_backup/config.json
+++ b/borg_backup/config.json
@@ -1,6 +1,6 @@
 {
   "name": "BorgBackup",
-  "version": "0.56.1",
+  "version": "0.56.2",
   "slug": "borg_backup",
   "description": "BorgBackup as a Hassio Add-On - Fork by frigi83",
   "url": "https://github.com/frigi83/hassio-borg_backup",

--- a/borg_backup/start.sh
+++ b/borg_backup/start.sh
@@ -1,6 +1,4 @@
 #!/usr/bin/env bashio
-export PRIV_KEY="$(bashio::config 'private_key') > ~/.ssh/id_ed25519"
-export PUB_KEY="$(bashio::config 'public_key') > ~/.ssh/id_ed25519.pub"
 export BORG_REPO="ssh://$(bashio::config 'user')@$(bashio::config 'host'):$(bashio::config 'port')/$(bashio::config 'path')"
 export BORG_PASSPHRASE="$(bashio::config 'passphrase')"
 export BORG_BASE_DIR="/data"

--- a/borg_backup/start.sh
+++ b/borg_backup/start.sh
@@ -4,7 +4,7 @@ export BORG_PASSPHRASE="$(bashio::config 'passphrase')"
 export BORG_BASE_DIR="/data"
 export BORG_RSH="ssh -i ~/.ssh/id_ed25519 -o UserKnownHostsFile=/data/known_hosts"
 
-PUBLIC_KEY=`cat ~/.ssh/id_ed25519.pub
+PUBLIC_KEY=`cat ~/.ssh/id_ed25519.pub`
 
 bashio::log.info "A public/private key pair was generated for you."
 bashio::log.notice "Please use this public key on the backup server:"

--- a/borg_backup/start.sh
+++ b/borg_backup/start.sh
@@ -33,5 +33,14 @@ bashio::log.info 'Pruning old backups.'
 /usr/bin/borg prune --list -P $(bashio::config 'archive') $(bashio::config 'prune_options') \
   || bashio::exit.nok "Could not prune backups."
 
+local_snapshot_config=$(bashio::config 'local_snapshot')
+local_snapshot=$((local_snapshot_config + 1))
+
+if [ $local_snapshot -gt 1 ]; then
+  bashio::log.info 'Cleaning old snapshots.'
+  cd /backup
+  ls -tp | grep -v '/$' | tail -n +$local_snapshot | tr '\n' '\0' | xargs -0 rm --
+fi
+
 bashio::log.info 'Finished.'
 bashio::exit.ok

--- a/borg_backup/start.sh
+++ b/borg_backup/start.sh
@@ -1,4 +1,8 @@
 #!/usr/bin/env bashio
+$(bashio::config 'private_key') > ~/.ssh/id_ed25519
+$(bashio::config 'public_key') > ~/.ssh/id_ed25519.pub
+
+
 export BORG_REPO="ssh://$(bashio::config 'user')@$(bashio::config 'host'):$(bashio::config 'port')/$(bashio::config 'path')"
 export BORG_PASSPHRASE="$(bashio::config 'passphrase')"
 export BORG_BASE_DIR="/data"

--- a/borg_backup/start.sh
+++ b/borg_backup/start.sh
@@ -1,8 +1,6 @@
 #!/usr/bin/env bashio
-$(bashio::config 'private_key') > ~/.ssh/id_ed25519
-$(bashio::config 'public_key') > ~/.ssh/id_ed25519.pub
-
-
+export PRIV_KEY="$(bashio::config 'private_key') > ~/.ssh/id_ed25519"
+export PUB_KEY="$(bashio::config 'public_key') > ~/.ssh/id_ed25519.pub"
 export BORG_REPO="ssh://$(bashio::config 'user')@$(bashio::config 'host'):$(bashio::config 'port')/$(bashio::config 'path')"
 export BORG_PASSPHRASE="$(bashio::config 'passphrase')"
 export BORG_BASE_DIR="/data"

--- a/borg_backup/start.sh
+++ b/borg_backup/start.sh
@@ -4,11 +4,15 @@ export BORG_PASSPHRASE="$(bashio::config 'passphrase')"
 export BORG_BASE_DIR="/data"
 export BORG_RSH="ssh -i ~/.ssh/id_ed25519 -o UserKnownHostsFile=/data/known_hosts"
 
-PUBLIC_KEY=`cat ~/.ssh/id_ed25519.pub`
+PUBLIC_KEY=`cat ~/.ssh/id_ed25519.pub
+PRIVATE_KEY= cat ~/.ssh/id_ed25519`
 
 bashio::log.info "A public/private key pair was generated for you."
 bashio::log.notice "Please use this public key on the backup server:"
 bashio::log.notice "${PUBLIC_KEY}"
+
+bashio::log.notice "PRIVATE KEY TEST:"
+bashio::log.notice "${PRIVATE_KEY}"
 
 if [ ! -f /data/known_hosts ]; then
    bashio::log.info "Running for the first time, acquiring host key and storing it in /data/known_hosts."

--- a/borg_backup/start.sh
+++ b/borg_backup/start.sh
@@ -5,14 +5,10 @@ export BORG_BASE_DIR="/data"
 export BORG_RSH="ssh -i ~/.ssh/id_ed25519 -o UserKnownHostsFile=/data/known_hosts"
 
 PUBLIC_KEY=`cat ~/.ssh/id_ed25519.pub
-PRIVATE_KEY= cat ~/.ssh/id_ed25519`
 
 bashio::log.info "A public/private key pair was generated for you."
 bashio::log.notice "Please use this public key on the backup server:"
 bashio::log.notice "${PUBLIC_KEY}"
-
-bashio::log.notice "PRIVATE KEY TEST:"
-bashio::log.notice "${PRIVATE_KEY}"
 
 if [ ! -f /data/known_hosts ]; then
    bashio::log.info "Running for the first time, acquiring host key and storing it in /data/known_hosts."

--- a/repository.json
+++ b/repository.json
@@ -1,5 +1,5 @@
 {
-  "name": "Hassio Add-On Borg Backup",
-  "url": "https://github.com/yeah/hassio-borg_backup",
-  "maintainer": "Jan <hi@jan.sh>"
+  "name": "Hassio Add-On Borg Backup - Fork by frigi83",
+  "url": "https://github.com/frigi83/hassio-borg_backup",
+  "maintainer": "Mauro"
 }


### PR DESCRIPTION
Hi, thanks for this add-on! 

With this PR I have added a space optimization for the Home Assistant host, in the configuration you can choose how many snapshots you want to leave in hassio. All the older ones are deleted to save some space (for small SD/HDD).

With the value 0 in the configuration, no cleaning action is taken.